### PR TITLE
Fix repo rename + package-name/install references

### DIFF
--- a/.github/QUICK_START.md
+++ b/.github/QUICK_START.md
@@ -13,7 +13,7 @@ Settings → Environments → New environment
 **On PyPI.org:**
 ```
 Account Settings → Publishing → Add GitHub OIDC publisher
-- Repository: xarf/xarf-parser-python
+- Repository: xarf/xarf-python
 - Workflow: publish-pypi.yml
 - Environment: pypi
 ```
@@ -29,7 +29,7 @@ Settings → Branches → Add rule
 Branch: main
 ☑ Require status checks:
   - Quality Checks / quality-checks
-  - Test Suite / test  
+  - Test Suite / test
   - CI Summary / ci-summary
 ☑ Require PR reviews: 1 approval
 ```

--- a/.github/WORKFLOWS_SUMMARY.md
+++ b/.github/WORKFLOWS_SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Successfully created 4 comprehensive GitHub Actions workflows for the xarf-parser-python project, adapted from abusix-parsers best practices while removing AWS/CodeArtifact dependencies.
+Successfully created 4 comprehensive GitHub Actions workflows for the xarf-python project, adapted from abusix-parsers best practices while removing AWS/CodeArtifact dependencies.
 
 ## Created Workflows
 
@@ -187,9 +187,9 @@ omit = ["tests/*", "setup.py"]
 Configure at https://pypi.org/manage/account/publishing/
 
 **PyPI Settings:**
-- Project: `xarf-parser`
+- Project: `xarf`
 - Owner: `xarf` (or your GitHub org/user)
-- Repository: `xarf-parser-python`
+- Repository: `xarf-python`
 - Workflow: `publish.yml`
 - Environment: `pypi`
 
@@ -378,9 +378,9 @@ Compared to sequential execution:
 
 4. **Add Badges to README**
    ```markdown
-   [![Quality](https://github.com/xarf/xarf-parser-python/actions/workflows/quality-checks.yml/badge.svg)](https://github.com/xarf/xarf-parser-python/actions/workflows/quality-checks.yml)
-   [![Tests](https://github.com/xarf/xarf-parser-python/actions/workflows/test.yml/badge.svg)](https://github.com/xarf/xarf-parser-python/actions/workflows/test.yml)
-   [![Security](https://github.com/xarf/xarf-parser-python/actions/workflows/security-scan.yml/badge.svg)](https://github.com/xarf/xarf-parser-python/actions/workflows/security-scan.yml)
+   [![Quality](https://github.com/xarf/xarf-python/actions/workflows/quality-checks.yml/badge.svg)](https://github.com/xarf/xarf-python/actions/workflows/quality-checks.yml)
+   [![Tests](https://github.com/xarf/xarf-python/actions/workflows/test.yml/badge.svg)](https://github.com/xarf/xarf-python/actions/workflows/test.yml)
+   [![Security](https://github.com/xarf/xarf-python/actions/workflows/security-scan.yml/badge.svg)](https://github.com/xarf/xarf-python/actions/workflows/security-scan.yml)
    ```
 
 5. **Monitor First Week**
@@ -399,5 +399,5 @@ Compared to sequential execution:
 
 **Implementation Date:** 2025-11-20
 **Based on:** abusix-parsers workflows
-**Adapted for:** xarf-parser-python (pip + setuptools)
+**Adapted for:** xarf-python (pip + setuptools)
 **Status:** ✅ Ready for testing

--- a/ARCHITECTURE_DELIVERABLES.md
+++ b/ARCHITECTURE_DELIVERABLES.md
@@ -339,9 +339,9 @@ json_output = report.model_dump_json(by_alias=True)
 ## Contact & Resources
 
 ### Repository
-- **GitHub**: https://github.com/xarf/xarf-parser-python
-- **Issues**: https://github.com/xarf/xarf-parser-python/issues
-- **Pull Requests**: https://github.com/xarf/xarf-parser-python/pulls
+- **GitHub**: https://github.com/xarf/xarf-python
+- **Issues**: https://github.com/xarf/xarf-python/issues
+- **Pull Requests**: https://github.com/xarf/xarf-python/pulls
 
 ### Documentation
 - **This Codebase**: `/docs/` directory
@@ -366,4 +366,4 @@ json_output = report.model_dump_json(by_alias=True)
 
 **Prepared by**: System Architecture Designer (Claude Code)
 **Date**: 2025-11-20
-**Project**: XARF Python Library (xarf-parser-python → xarf)
+**Project**: XARF Python Library (xarf-python, package: xarf)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,9 +213,9 @@ print(report.category)  # Clean Python access
 ## Links
 
 - [XARF v4 Specification](https://xarf.org/docs/specification/)
-- [GitHub Repository](https://github.com/xarf/xarf-parser-python)
-- [PyPI Package](https://pypi.org/project/xarf-parser/)
-- [Issue Tracker](https://github.com/xarf/xarf-parser-python/issues)
+- [GitHub Repository](https://github.com/xarf/xarf-python)
+- [Install from source](https://github.com/xarf/xarf-python) (alpha — not yet on PyPI)
+- [Issue Tracker](https://github.com/xarf/xarf-python/issues)
 - [XARF Website](https://xarf.org)
 
 ## Versioning

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@ Thank you for your interest in contributing to the XARF v4 Python parser! This d
 ### Installation
 ```bash
 # Clone your fork
-git clone https://github.com/YOUR_USERNAME/xarf-parser-python.git
-cd xarf-parser-python
+git clone https://github.com/YOUR_USERNAME/xarf-python.git
+cd xarf-python
 
 # Create virtual environment
 python -m venv venv
@@ -134,17 +134,17 @@ xarf/
 ```python
 def parse_report(self, json_data: Union[str, Dict[str, Any]]) -> XARFReport:
     """Parse XARF report from JSON data.
-    
+
     Args:
         json_data: JSON string or dictionary containing XARF report data
-        
+
     Returns:
         XARFReport: Parsed and validated report object
-        
+
     Raises:
         XARFParseError: If JSON parsing fails
         XARFValidationError: If validation fails in strict mode
-        
+
     Example:
         >>> parser = XARFParser()
         >>> report = parser.parse('{"xarf_version": "4.0.0", ...}')
@@ -171,30 +171,30 @@ except XARFParseError as e:
 ```python
 class TestMessagingReports:
     """Test parsing of messaging class reports."""
-    
+
     def test_valid_spam_report(self):
         """Test parsing of valid spam report."""
         report_data = {
             "xarf_version": "4.0.0",
             # ... complete valid data
         }
-        
+
         parser = XARFParser()
         report = parser.parse(report_data)
-        
+
         assert isinstance(report, MessagingReport)
         assert report.class_ == "messaging"
         assert report.type == "spam"
-    
+
     def test_missing_required_field(self):
         """Test handling of missing required fields."""
         invalid_data = {"xarf_version": "4.0.0"}  # Missing required fields
-        
+
         parser = XARFParser(strict=True)
-        
+
         with pytest.raises(XARFValidationError) as exc_info:
             parser.parse(invalid_data)
-        
+
         assert "Missing required fields" in str(exc_info.value)
 ```
 

--- a/PIPELINE_SUMMARY.md
+++ b/PIPELINE_SUMMARY.md
@@ -1,7 +1,7 @@
 # XARF Python Parser - CI/CD Pipeline Implementation Summary
 
-**Created**: 2025-11-20  
-**Based on**: abusix-parsers quality standards  
+**Created**: 2025-11-20
+**Based on**: abusix-parsers quality standards
 **Status**: ✅ Complete and Ready for Use
 
 ---
@@ -105,7 +105,7 @@ Push/PR → continuous-integration.yml
 ```
 Every Monday 9 AM UTC (or manual)
   ├─ pip-audit
-  ├─ bandit  
+  ├─ bandit
   ├─ trivy
   └─ Create issue if failures
 ```
@@ -154,16 +154,16 @@ All based on abusix-parsers standards:
 
 ## Memory Key
 
-**Storage Location**: 
+**Storage Location**:
 ```
-/Users/tknecht/Projects/xarf/xarf-parser-python/docs/ci-cd-pipeline-design.md
+/Users/tknecht/Projects/xarf/xarf-python/docs/ci-cd-pipeline-design.md
 ```
 
 **Memory Key**: `xarf-python/workflows`
 
-**Quick Reference**: 
+**Quick Reference**:
 ```
-/Users/tknecht/Projects/xarf/xarf-parser-python/PIPELINE_SUMMARY.md
+/Users/tknecht/Projects/xarf/xarf-python/PIPELINE_SUMMARY.md
 ```
 
 ## Testing the Pipeline
@@ -224,9 +224,9 @@ Select: ☑ Publish to Test PyPI
 
 ---
 
-**Pipeline Status**: ✅ Production Ready  
-**Documentation**: ✅ Complete  
-**Testing**: ⏳ Awaiting GitHub setup  
+**Pipeline Status**: ✅ Production Ready
+**Documentation**: ✅ Complete
+**Testing**: ⏳ Awaiting GitHub setup
 **Deployment**: ⏳ Awaiting PyPI configuration
 
-**All files are located at**: `/Users/tknecht/Projects/xarf/xarf-parser-python/`
+**All files are located at**: `/Users/tknecht/Projects/xarf/xarf-python/`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # XARF v4 Python Parser
 
 [![CI](https://github.com/xarf/xarf-python/actions/workflows/ci.yml/badge.svg)](https://github.com/xarf/xarf-python/actions/workflows/ci.yml)
-[![PyPI version](https://badge.fury.io/py/xarf-parser.svg)](https://pypi.org/project/xarf-parser/)
-[![Python versions](https://img.shields.io/pypi/pyversions/xarf-parser.svg)](https://pypi.org/project/xarf-parser/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Security Policy](https://img.shields.io/badge/Security-Policy-blue.svg)](SECURITY.md)
 
@@ -27,12 +25,12 @@ This library is currently in **alpha** development (v4.0.0-alpha). It supports t
 ## 📦 Installation
 
 ```bash
-# Alpha releases (recommended for early testing)
-pip install xarf-parser==4.0.0a1
+# Install from source (alpha — not yet on PyPI, install from source)
+pip install git+https://github.com/xarf/xarf-python.git
 
 # Install from source for latest development
-git clone https://github.com/xarf/xarf-parser-python.git
-cd xarf-parser-python
+git clone https://github.com/xarf/xarf-python.git
+cd xarf-python
 pip install -e .
 
 # Install with development dependencies
@@ -423,8 +421,8 @@ def verify_evidence_hash(evidence_item: dict) -> bool:
 
 ```bash
 # Setup development environment
-git clone https://github.com/xarf/xarf-parser-python.git
-cd xarf-parser-python
+git clone https://github.com/xarf/xarf-python.git
+cd xarf-python
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -e ".[dev,test]"
@@ -529,7 +527,7 @@ This project follows semantic versioning with alpha/beta releases:
 ## 💬 Support
 
 - **Documentation**: https://xarf.org
-- **GitHub Issues**: https://github.com/xarf/xarf-parser-python/issues
+- **GitHub Issues**: https://github.com/xarf/xarf-python/issues
 - **Discussions**: https://github.com/xarf/xarf-spec/discussions
 - **Email**: contact@xarf.org
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -79,11 +79,8 @@ print(report.to_json())
 ### Step 1: Update Dependencies
 
 ```bash
-# Upgrade to latest version
-pip install --upgrade xarf-parser>=4.0.0
-
-# Or specify exact version
-pip install xarf-parser==4.0.0
+# Install latest version (alpha — not yet on PyPI, install from source)
+pip install git+https://github.com/xarf/xarf-python.git
 ```
 
 ### Step 2: Code Changes

--- a/docs/DEPRECATED.md
+++ b/docs/DEPRECATED.md
@@ -339,7 +339,7 @@ def check_for_deprecations():
 
 - GitHub Watch: https://github.com/xarf/xarf-python
 - Release RSS: https://github.com/xarf/xarf-python/releases.atom
-- PyPI RSS: https://pypi.org/rss/project/xarf-parser/releases.xml
+- GitHub Tags: https://github.com/xarf/xarf-python/tags
 
 ---
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -4,8 +4,8 @@
 
 ```bash
 # Clone the repository
-git clone https://github.com/xarf/xarf-parser-python.git
-cd xarf-parser-python
+git clone https://github.com/xarf/xarf-python.git
+cd xarf-python
 
 # Create and activate virtual environment
 python3 -m venv venv
@@ -212,7 +212,7 @@ echo 'export PIP_INDEX_URL=https://pypi.org/simple/' >> ~/.zshrc
 
 ## Getting Help
 
-- GitHub Issues: https://github.com/xarf/xarf-parser-python/issues
+- GitHub Issues: https://github.com/xarf/xarf-python/issues
 - XARF Specification: https://github.com/xarf/xarf-spec
 - Email: contact@xarf.org
 

--- a/docs/generator_usage.md
+++ b/docs/generator_usage.md
@@ -409,4 +409,4 @@ print(json.dumps(report, indent=2))
 
 - [XARF Specification](https://xarf.org)
 - [XARF Parser Documentation](../README.md)
-- [GitHub Repository](https://github.com/xarf/xarf-parser-python)
+- [GitHub Repository](https://github.com/xarf/xarf-python)

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -378,7 +378,7 @@ if failed:
 ## Support and Questions
 
 - **Specification**: See [XARF v4 Specification](https://github.com/xarf/xarf-spec)
-- **Issues**: Report bugs at [GitHub Issues](https://github.com/xarf/xarf-parser-python/issues)
+- **Issues**: Report bugs at [GitHub Issues](https://github.com/xarf/xarf-python/issues)
 - **Community**: Join discussions at [XARF Discussions](https://github.com/xarf/xarf-spec/discussions)
 
 ## Timeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ dependencies = [
 
 [project.urls]
 "Homepage" = "https://xarf.org"
-"Documentation" = "https://github.com/xarf/xarf-parser-python"
-"Repository" = "https://github.com/xarf/xarf-parser-python"
-"Bug Reports" = "https://github.com/xarf/xarf-parser-python/issues"
+"Documentation" = "https://github.com/xarf/xarf-python"
+"Repository" = "https://github.com/xarf/xarf-python"
+"Bug Reports" = "https://github.com/xarf/xarf-python/issues"
 "Specification" = "https://github.com/xarf/xarf-spec"
-"Changelog" = "https://github.com/xarf/xarf-parser-python/blob/master/CHANGELOG.md"
+"Changelog" = "https://github.com/xarf/xarf-python/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

The repo was renamed `xarf-parser-python` → `xarf-python`. This PR fixes stale references across docs and metadata. **Docs/metadata only — no source-code, version, or API changes.**

### Changes
- Replace `xarf-parser-python` → `xarf-python` in all GitHub URLs and clone/cd commands.
- Fix `master` → `main` in this repo's GitHub URLs (`pyproject.toml` changelog link).
- The PyPI package `xarf` is **not yet published**. Replace `pip install xarf-parser==...` / `pip install xarf-parser` with `pip install git+https://github.com/xarf/xarf-python.git`, noting "(alpha — not yet on PyPI, install from source)" where natural.
- Remove the two broken PyPI badges from `README.md` (`badge.fury.io/py/xarf-parser`, `shields.io/pypi/pyversions/xarf-parser`) that pointed to a non-existent package. Kept CI, License, and Security badges.
- Fixed stale package/repo names + hardcoded local paths in internal dev notes (`PIPELINE_SUMMARY.md`, `.github/QUICK_START.md`, `.github/WORKFLOWS_SUMMARY.md`).
- `CHANGELOG.md` / `docs/DEPRECATED.md`: repointed dead PyPI links to source/GitHub equivalents.

> Note: pre-commit's `safety` hook fails in this environment for an unrelated reason (it only supports Poetry-style `pyproject.toml`); the whitespace/EOF hooks auto-fixed a few trailing-whitespace lines, which are included.

### Out of scope (flagged, NOT changed)
- README documents `xarf.validation.validate_xarf_report`, which **does not exist** in `src/`.
- Orphaned/stale `v4.0.0` git tag.
- Dead `[tool.setuptools.package-data]` glob `xarf = ["schemas/*.json"]` — no `src/xarf/schemas/` dir exists.
- `tests/shared/README.md` is a vendored doc referencing sibling repos (`xarf-parser-tests`, `xarf-parser-go`) and an npm example — left untouched to avoid misrepresenting other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)